### PR TITLE
Update Maven compiler to Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,14 +6,17 @@
     <groupId>br.com.drti</groupId>
     <artifactId>DRTI</artifactId>
     <version>1</version>
+    <properties>
+        <maven.compiler.release>11</maven.compiler.release>
+    </properties>
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>7</source>
-                    <target>7</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
## Summary
- update maven-compiler-plugin configuration to Java 11
- add `maven.compiler.release` property

## Testing
- `apt-get update`
- `apt-get install -y maven`
- `mvn -q clean compile` *(fails: Plugin org.apache.maven.plugins:maven-clean-plugin:2.5 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_6849c420d59c8321a95f46fb399a41a9